### PR TITLE
fix issue 83 with new middlewares

### DIFF
--- a/src/http/gostserver.go
+++ b/src/http/gostserver.go
@@ -1,15 +1,17 @@
 package http
 
 import (
-	"log"
-	"net/http"
-	"strconv"
-	"strings"
-
 	"context"
 	"fmt"
 	"github.com/geodan/gost/src/sensorthings/models"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"time"
+	//"net/http/httptest"
+	"github.com/geodan/gost/src/sensorthings/rest"
 )
 
 // Server interface for starting and stopping the HTTP server
@@ -42,7 +44,7 @@ func CreateServer(host string, port int, api *models.API, https bool, httpsCert,
 		httpsKey:  httpsKey,
 		httpServer: &http.Server{
 			Addr:         fmt.Sprintf("%s:%s", host, strconv.Itoa(port)),
-			Handler:      LowerCaseURI(router),
+			Handler:      HandleExternalUri(LowerCaseURI(router)),
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: 30 * time.Second,
 		},
@@ -112,5 +114,24 @@ func LowerCaseURI(h http.Handler) http.Handler {
 		h.ServeHTTP(w, r)
 	}
 
+	return http.HandlerFunc(fn)
+}
+
+func HandleExternalUri(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, r)
+			bytes := rec.Body.Bytes()
+			s := string(bytes)
+			if len(s) > 0 {
+				forwarded_uri := r.Header.Get("X-Forwarded-For")
+				if len(forwarded_uri) > 0 {
+					orig_uri := rest.ExternalURI
+					s = strings.Replace(s, orig_uri, forwarded_uri, -1)
+				}
+
+			}
+			w.Write([]byte(s))
+		}
 	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
adds middleware to change the response when there is a x-forwarded-header in the request.  Change involves replaces ExternalUri with the Uri in the x-forwarded-header.